### PR TITLE
Fixed missing escape when escaping null.

### DIFF
--- a/KeyWordIO/readLineWithoutCache.mo
+++ b/KeyWordIO/readLineWithoutCache.mo
@@ -60,7 +60,7 @@ const char* ReadLine(const char *fileName, int lineNumber, int* endOfFile)
                 }
         }
         fclose(fp);
-        strline[lineLen-1]='\0';
+        strline[lineLen-1]='\\0';
         line=ModelicaAllocateString(lineLen);
         strcpy(line, strline);
         *endOfFile=0;


### PR DESCRIPTION
\0 should be escaped to \0.
